### PR TITLE
feat: Track VE and section edit buttons

### DIFF
--- a/resources/ext.plausible.scripts.track-edit-btn/track-edit-btn.js
+++ b/resources/ext.plausible.scripts.track-edit-btn/track-edit-btn.js
@@ -1,17 +1,29 @@
 // Edit Button Tracking
 ( function () {
-	var eventName = 'EditButtonClick',
-		btn = document.querySelector( '#ca-edit a' );
+  if ( typeof window.plausible === 'undefined' ) {
+	return;
+  }
+  
+  var registerEvent = function() {
+    var eventName = 'EditButtonClick';
+    window.plausible( eventName, {
+        props: {
+          path: document.location.pathname
+        }
+    } );
+  };
+  
+  var btns = {
+    edit: document.querySelector( '#ca-edit a' ),
+    veEdit: document.querySelector( '#ca-ve-edit a' ),
+    // This is not great but there is no good selector to get the regular edit button
+    sectionEdit: document.querySelector( '.mw-editsection a:last-of-type' ),
+    sectionVeEdit: document.querySelector( '.mw-editsection-visualeditor a' )
+  };
 
-	if ( typeof window.plausible === 'undefined' || btn === null ) {
-		return;
-	}
-
-	btn.addEventListener( 'click', function () {
-		window.plausible( eventName, {
-			props: {
-				path: document.location.pathname
-			}
-		} );
-	} );
+  for( var btn in btns ) {
+    if( btn !== null ) {
+      btn.addEventListener( 'click', registerEvent );
+    }
+  }
 }() );


### PR DESCRIPTION
* Track VE edit button when user is shown two edit buttons
* Track section edit button

Note: There is no good non-hacky way to select the section edit button since it has no class. Some other extensions (e.g. [Extension:HideSection](https://www.mediawiki.org/wiki/Extension:HideSection)) add links to there as well. Technically the most accurate way is probably using a wildcard `href` selector to catch both `action=edit` and `veaction=editsource` but it is not foolproof either, it is up to you to decide whether it is worth it to accurately capture those.