### PR TITLE
refactor: Update link selector

### DIFF
--- a/resources/ext.plausible.scripts.citizen.track-menu-links/track-menu-links.js
+++ b/resources/ext.plausible.scripts.citizen.track-menu-links/track-menu-links.js
@@ -6,7 +6,7 @@
 		return;
 	}
 
-	document.querySelectorAll( '#mw-drawer-menu .mw-portal li a' ).forEach( function ( link ) {
+	document.querySelectorAll( '.citizen-drawer__menu .mw-portal a' ).forEach( function ( link ) {
 		link.addEventListener( 'click', function ( event ) {
 			if ( typeof event.target.href !== 'undefined' && event.target.href !== null ) {
 				event.preventDefault();


### PR DESCRIPTION
Citizen has changed its header DOM since the 1.16.0 update.
`#mw-drawer-menu` is replaced by `.citizen-drawer__menu`.
Also remove the unnecessary `<li>` specificity

@octfx you might want to merge this when you update the skin.